### PR TITLE
Support batch bucket deletion and object uploads

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -53,7 +53,7 @@ pub enum Commands {
     #[command(visible_alias = "lsb")]
     ListBuckets,
 
-    /// Delete a single bucket
+    /// Delete one or more buckets
     #[command(visible_alias = "rmb")]
     DeleteBucket(DeleteBucketArgs),
 
@@ -61,7 +61,7 @@ pub enum Commands {
     #[command(visible_alias = "ls")]
     ListObjects(ListObjectsArgs),
 
-    /// Upload an object to a bucket
+    /// Upload one or more objects to a bucket
     #[command(visible_alias = "put")]
     UploadObject(UploadObjectArgs),
 
@@ -72,15 +72,6 @@ pub enum Commands {
     /// Delete an object from a bucket
     #[command(visible_alias = "rm")]
     DeleteObject(DeleteObjectArgs),
-
-    // TODO unify plural commands with normal commands
-    /// (experimental) Delete multiple buckets
-    #[command(visible_alias = "rmbs")]
-    DeleteBuckets(DeleteBucketsArgs),
-
-    /// (experimental) Upload multiple objects to a bucket
-    #[command(visible_alias = "puts")]
-    UploadObjects(UploadObjectsArgs),
 
     /// List Huawei Cloud regions
     #[command(visible_alias = "regions")]
@@ -113,14 +104,8 @@ pub struct ListObjectsArgs {
 
 #[derive(Args)]
 pub struct DeleteBucketArgs {
-    /// The bucket to delete
-    pub bucket: String,
-}
-
-#[derive(Args)]
-pub struct DeleteBucketsArgs {
-    /// List of (space separated) bucket names to delete
-    #[arg(short, long, num_args = 1..)]
+    /// One or more bucket names to delete
+    #[arg(num_args(1..))]
     pub buckets: Vec<String>,
 }
 
@@ -128,22 +113,12 @@ pub struct DeleteBucketsArgs {
 pub struct UploadObjectArgs {
     /// The bucket to upload to
     pub bucket: String,
-    /// File path
-    #[arg(short, long)]
-    pub file_path: String,
-    /// Optional object path
+    /// One or more local file paths to upload. The object key will be the filename.
+    #[arg(short = 'f', long = "file-path", num_args(1..))]
+    pub file_paths: Vec<String>,
+    /// Optional object path for single-file uploads
     #[arg(short, long)]
     pub object_path: Option<String>,
-}
-
-#[derive(Args)]
-pub struct UploadObjectsArgs {
-    /// The bucket to upload to
-    #[arg(short, long)]
-    pub bucket: String,
-    /// One or more local file paths to upload. The object key will be the filename.
-    #[arg(short, long, num_args(1..))]
-    pub files: Vec<String>,
 }
 
 #[derive(Args)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,15 +21,14 @@ use crate::error::log_error_chain;
 use crate::obs::{
     // OBS operations
     create_bucket,
-    delete_bucket,
-    delete_multiple_buckets,
+    delete_buckets,
     delete_object,
     download_object,
     list_buckets,
     list_objects,
     list_regions,
-    upload_multiple_objects,
     upload_object,
+    upload_objects,
 };
 
 // Maximum allowed edit distance for fuzzy region name matching
@@ -119,34 +118,30 @@ async fn main() -> Result<()> {
                 }
                 Commands::DeleteBucket(sub_args) => {
                     debug!("Executing 'delete-bucket' command");
-                    delete_bucket(&client, &sub_args.bucket, project_name, &credentials).await
-                }
-                Commands::DeleteBuckets(sub_args) => {
-                    debug!("Executing 'delete-buckets' command");
-                    delete_multiple_buckets(&client, sub_args.buckets, project_name, &credentials).await
+                    delete_buckets(&client, sub_args.buckets, project_name, &credentials).await
                 }
                 Commands::UploadObject(sub_args) => {
                     debug!("Executing 'upload-object' command");
-                    upload_object(
-                        &client,
-                        &sub_args.bucket,
-                        project_name,
-                        &sub_args.file_path,
-                        &sub_args.object_path,
-                        &credentials,
-                    )
-                    .await
-                }
-                Commands::UploadObjects(sub_args) => {
-                    debug!("Executing 'upload-objects' command");
-                    upload_multiple_objects(
-                        &client,
-                        &sub_args.bucket,
-                        project_name,
-                        sub_args.files,
-                        &credentials,
-                    )
-                    .await
+                    if sub_args.file_paths.len() == 1 {
+                        upload_object(
+                            &client,
+                            &sub_args.bucket,
+                            project_name,
+                            &sub_args.file_paths[0],
+                            &sub_args.object_path,
+                            &credentials,
+                        )
+                        .await
+                    } else {
+                        upload_objects(
+                            &client,
+                            &sub_args.bucket,
+                            project_name,
+                            sub_args.file_paths,
+                            &credentials,
+                        )
+                        .await
+                    }
                 }
                 Commands::DownloadObject(sub_args) => {
                     debug!("Executing 'download-object' command");

--- a/src/obs.rs
+++ b/src/obs.rs
@@ -307,7 +307,7 @@ pub async fn delete_bucket(
 }
 
 /// Deletes multiple buckets asynchronously from OBS
-pub async fn delete_multiple_buckets(
+pub async fn delete_buckets(
     client: &Client,
     buckets: Vec<String>,
     region: String,
@@ -618,8 +618,8 @@ pub async fn download_object(
     Ok(())
 }
 
-/// Upload multiple object to a bucket
-pub async fn upload_multiple_objects(
+/// Upload multiple objects to a bucket
+pub async fn upload_objects(
     client: &Client,
     bucket_name: &str,
     region: String,


### PR DESCRIPTION
## Summary
- allow `delete-bucket` and `upload-object` to receive multiple targets
- remove experimental commands and wire batch ops into main
- add `delete_buckets` and `upload_objects` helpers for list processing

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b0e1a994f0832ba231538c950d12ed